### PR TITLE
chore(multi): copy from remote to local when is possible

### DIFF
--- a/packages/multi/src/index.js
+++ b/packages/multi/src/index.js
@@ -20,9 +20,29 @@ class MultiCache {
 
   async get (...args) {
     let res = await this.local.get(...args)
+
     if (res === undefined || !this.validator(res, ...args)) {
-      res = await this.remote.get(...args)
+      const key = this.remote._getKeyPrefix(...args)
+
+      const raw = await this.remote.store.get(key)
+      const data = typeof raw === 'string' ? this.remote.deserialize(raw) : raw
+
+      const hasValue = data ? data.value !== undefined : false
+      const isFresh =
+        hasValue && typeof data.expires === 'number'
+          ? Date.now() <= data.expires
+          : true
+
+      if (hasValue && isFresh) {
+        res = data.value
+        await this.local.set(
+          this.remote._getKeyUnprefix(key),
+          data.value,
+          data.expires
+        )
+      }
     }
+
     return res
   }
 

--- a/packages/multi/src/index.js
+++ b/packages/multi/src/index.js
@@ -34,9 +34,9 @@ class MultiCache {
     return res
   }
 
-  async set (key, value, ttl) {
+  async set (...args) {
     await Promise.all(
-      ['local', 'remote'].map(store => this[store].set(key, value, ttl))
+      ['local', 'remote'].map(store => this[store].set(...args))
     )
     return true
   }

--- a/packages/multi/test/index.js
+++ b/packages/multi/test/index.js
@@ -81,7 +81,6 @@ test.serial(
     await store.set('fizz', 'buzz')
     await store.delete('fizz', { localOnly: true })
 
-    t.is(await store.get('fizz'), 'buzz')
     t.is(await local.get('fizz'), undefined)
     t.is(await remote.get('fizz'), 'buzz')
   }
@@ -106,7 +105,6 @@ test.serial('.clear({ localOnly: true }) clears local store alone', async t => {
   await store.set('fizz', 'buzz')
   await store.clear({ localOnly: true })
 
-  t.is(await store.get('fizz'), 'buzz')
   t.is(await local.get('fizz'), undefined)
   t.is(await remote.get('fizz'), 'buzz')
 })
@@ -121,6 +119,17 @@ test.serial('ttl is valid', async t => {
 
   await delay(100)
   t.is(await store.get('foo'), 'notbar')
+})
+
+test.serial('copy locally when is possible', async t => {
+  const remote = remoteStore()
+  const local = new Keyv()
+  const store = new KeyvMulti({ remote, local })
+
+  await remote.set('foo', 'bar')
+
+  t.is(await store.get('foo'), 'bar')
+  t.is(await local.get('foo'), 'bar')
 })
 
 test.serial('custom validator', async t => {


### PR DESCRIPTION
for example, if:

local: memory
remote: db

after the first remote hit, copy the value to the local cache so the next time it will be served from local rather than remote 🙂