### PR TITLE
build: move to turbo & pnpm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,14 @@ jobs:
         sudo -u postgres psql --command="ALTER ROLE postgres WITH PASSWORD 'postgres';" --command="\du"
         sudo systemctl restart postgresql.service
         pg_isready
-    - run: npm install --no-package-lock
-    - run: npm test
+    - name: Setup PNPM
+      uses: pnpm/action-setup@v2.0.1
+      with:
+        version: 6.24.4
+        run_install: true
+    - run: pnpm test
     - name: Coverage
-      run: npm run coverage
+      run: pnpm coverage
     - name: Upload
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Setup PNPM
       uses: pnpm/action-setup@v2.0.1
       with:
-        version: 6.24.4
+        version: latest
         run_install: true
     - run: pnpm test
     - name: Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ package-lock.json
 #yarn
 yarn.lock
 
+#pnpm 
+pnpm-lock.yaml
+
+#turbo
+.turbo
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
   ],
   "scripts": {
     "build": "gulp build",
-    "clean": "lerna clean && rm -rf node_modules",
+    "clean": "pnpm exec \"rimraf\" node_modules && rimraf node_modules",
     "contributors": "(pnpm -r exec finepack --parallel && git-authors-cli && finepack && echo \"git add package.json && git commit -m 'build: contributors' --no-verify\") || true",
     "coverage": "node scripts/merge-reports && mkdir -p coverage && nyc report --reporter=text-lcov > coverage/lcov.info",
     "dev": "concurrently \"gulp\" \"npm run dev:server\"",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
   ],
   "scripts": {
     "build": "gulp build",
-    "clean": "pnpm exec \"rimraf\" node_modules && rimraf node_modules",
+    "clean": "pnpm exec rm --rf node_modules && rm --rf node_modules",
     "contributors": "(pnpm -r exec finepack --parallel && git-authors-cli && finepack && echo \"git add package.json && git commit -m 'build: contributors' --no-verify\") || true",
     "coverage": "node scripts/merge-reports && mkdir -p coverage && nyc report --reporter=text-lcov > coverage/lcov.info",
     "dev": "concurrently \"gulp\" \"npm run dev:server\"",

--- a/package.json
+++ b/package.json
@@ -186,8 +186,10 @@
     "npm-check-updates": "latest",
     "nyc": "latest",
     "prettier-standard": "latest",
+    "rimraf": "latest",
     "simple-git-hooks": "latest",
-    "standard": "latest"
+    "standard": "latest",
+    "turbo": "latest"
   },
   "engines": {
     "node": ">= 12"
@@ -197,21 +199,20 @@
   ],
   "scripts": {
     "build": "gulp build",
-    "clean": "lerna clean --yes && rm -rf node_modules",
-    "contributors": "(lerna exec finepack --parallel && git-authors-cli && finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
+    "clean": "lerna clean && rm -rf node_modules",
+    "contributors": "(pnpm -r exec finepack --parallel && git-authors-cli && finepack && echo \"git add package.json && git commit -m 'build: contributors' --no-verify\") || true",
     "coverage": "node scripts/merge-reports && mkdir -p coverage && nyc report --reporter=text-lcov > coverage/lcov.info",
     "dev": "concurrently \"gulp\" \"npm run dev:server\"",
     "dev:server": "browser-sync start --server --files \"index.html, README.md, static/**/*.(css|js)\"",
-    "install": "lerna bootstrap --no-ci --force-local",
     "lint": "standard",
-    "prerelease": "npm run contributors",
-    "pretest": "npm run lint",
+    "prerelease": "contributors",
+    "pretest": "lint",
     "release": "lerna publish --yes --sort --conventional-commits -m \"chore(release): %s\" --create-release github",
-    "test": "lerna run test",
-    "update": "lerna exec ncu -- --upgrade && ncu -- --upgrade",
-    "update:check": "lerna exec ncu -- --errorLevel 2 && ncu -- --errorLevel 2"
+    "test": "turbo run test",
+    "update": "pnpm -r exec ncu -- --upgrade && ncu -- --upgrade",
+    "update:check": "pnpm -r exec ncu -- --errorLevel 2 && ncu -- --errorLevel 2"
   },
-  "private": "true",
+  "private": true,
   "license": "MIT",
   "commitlint": {
     "extends": [
@@ -232,5 +233,15 @@
   "simple-git-hooks": {
     "commit-msg": "npx commitlint --edit",
     "pre-commit": "npx nano-staged"
+  },
+  "turbo": {
+    "pipeline": {
+      "lint": {
+        "outputs": []
+      },
+      "test": {
+        "outputs": []
+      }
+    }
   }
 }

--- a/packages/compress/package.json
+++ b/packages/compress/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@keyvhq/core": "latest",
-    "ava": "3",
+    "ava": "latest",
     "delay": "latest",
     "nyc": "latest"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "timekeeper": "latest",
     "tsd": "latest",

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -31,7 +31,7 @@
     "mimic-fn": "~3.0.0"
   },
   "devDependencies": {
-    "ava": "3",
+    "ava": "latest",
     "delay": "latest",
     "nyc": "latest"
   },

--- a/packages/memoize/test/index.js
+++ b/packages/memoize/test/index.js
@@ -111,23 +111,24 @@ test('should not cache error', async t => {
   t.is(called, 2)
 })
 
-test('should return fresh result', async t => {
-  const keyv = new Keyv()
+// Disabled as it is failing in CI unexpectedly
+// test('should return fresh result', async t => {
+//   const keyv = new Keyv()
 
-  let called = 0
+//   let called = 0
 
-  const fn = n => {
-    ++called
-    return asyncSum(n)
-  }
+//   const fn = n => {
+//     ++called
+//     return asyncSum(n)
+//   }
 
-  const memoizedSum = memoize(fn, keyv, { staleTtl: 100 })
-  keyv.set(5, 5, 200)
-  await delay(10)
+//   const memoizedSum = memoize(fn, keyv, { staleTtl: 100 })
+//   keyv.set(5, 5, 200)
+//   await delay(10)
 
-  t.is(await memoizedSum(5), 5)
-  t.is(called, 0)
-})
+//   t.is(await memoizedSum(5), 5)
+//   t.is(called, 0)
+// })
 
 test('should return stale result but refresh', async t => {
   const keyv = new Keyv()

--- a/packages/memoize/test/index.js
+++ b/packages/memoize/test/index.js
@@ -111,24 +111,23 @@ test('should not cache error', async t => {
   t.is(called, 2)
 })
 
-// Disabled as it is failing in CI unexpectedly
-// test('should return fresh result', async t => {
-//   const keyv = new Keyv()
+test.serial('should return fresh result', async t => {
+  const keyv = new Keyv()
 
-//   let called = 0
+  let called = 0
 
-//   const fn = n => {
-//     ++called
-//     return asyncSum(n)
-//   }
+  const fn = n => {
+    ++called
+    return asyncSum(n)
+  }
 
-//   const memoizedSum = memoize(fn, keyv, { staleTtl: 100 })
-//   keyv.set(5, 5, 200)
-//   await delay(10)
+  const memoizedSum = memoize(fn, keyv, { staleTtl: 100 })
+  keyv.set(5, 5, 200)
+  await delay(10)
 
-//   t.is(await memoizedSum(5), 5)
-//   t.is(called, 0)
-// })
+  t.is(await memoizedSum(5), 5)
+  t.is(called, 0)
+})
 
 test('should return stale result but refresh', async t => {
   const keyv = new Keyv()

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "tsd": "latest",
     "typescript": "latest"

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@keyvhq/sqlite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "delay": "latest",
     "nyc": "latest"
   },

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -30,7 +30,7 @@
     "@keyvhq/core": "^1.6.3"
   },
   "devDependencies": {
-    "@keyvhq/keyv-sqlite": "latest",
+    "@keyvhq/sqlite": "latest",
     "ava": "3",
     "delay": "latest",
     "nyc": "latest"

--- a/packages/multi/test/index.js
+++ b/packages/multi/test/index.js
@@ -5,7 +5,7 @@ const delay = require('delay')
 
 const KeyvMulti = require('..')
 const Keyv = require('@keyvhq/core')
-const KeyvSqlite = require('@keyvhq/keyv-sqlite')
+const KeyvSqlite = require('@keyvhq/sqlite')
 
 const remoteStore = () =>
   new Keyv({

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "tsd": "latest",
     "typescript": "latest"

--- a/packages/offline/package.json
+++ b/packages/offline/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/client-s3": "latest",
     "@keyvhq/core": "latest",
     "@keyvhq/redis": "latest",
-    "ava": "3",
+    "ava": "latest",
     "delay": "latest",
     "keyv-s3": "latest",
     "nyc": "latest"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "tsd": "latest",
     "typescript": "latest"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -36,7 +36,7 @@
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
     "@types/ioredis": "^4.27.7",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "tsd": "latest",
     "typescript": "latest"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "pify": "^5.0.0",
     "sqlite3": "^5.0.2"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@keyvhq/core": "latest",
     "@keyvhq/test-suite": "latest",
-    "ava": "3",
+    "ava": "latest",
     "nyc": "latest",
     "tsd": "latest",
     "typescript": "latest"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
Lerna is still used for the `clean`  and `publish` commands, we could try to use rimraf for clean and [changesets](https://github.com/changesets/changesets) for publishing

`pnpm` is needed for installing ( It automatically links and installs the packages node_modules, similar to lerna bootstrap )
`turbo` is used for running tests

Signed-off-by: Jytesh <44925963+Jytesh@users.noreply.github.com>