### PR TITLE
update READMEs for postgres and sqlite to match constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Just create a new **Keyv** instance, using an specific storage adapter:
 const keyv = new Keyv() // in-memory, by default
 const keyvRedis = new Keyv({ store: new KeyvRedis('redis://user:pass@localhost:6379')})
 const keyvMongo = new Keyv({ store: new KeyvMongo('mongodb://user:pass@localhost:27017/dbname')})
-const keyvSQLite = new Keyv({ store: new KeyvSQLite('sqlite://path/to/database.sqlite')})
-const keyvPostgreSQL = new Keyv({ store: new KeyvPostgreSQL('postgresql://user:pass@localhost:5432/dbname')})
+const keyvSQLite = new Keyv({ store: new KeyvSQLite({ uri: 'sqlite://path/to/database.sqlite' })})
+const keyvPostgreSQL = new Keyv({ store: new KeyvPostgreSQL({ uri: 'postgresql://user:pass@localhost:5432/dbname' })})
 const keyvMySQL = new Keyv({ store: new KeyvMySQL('mysql://user:pass@localhost:3306/dbname')})
 
 // Handle database connection errors

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -35,7 +35,8 @@ const KeyvPostgres = require('@keyvhq/postgres')
 const Keyv = require('@keyvhq/core')
 
 const keyv = new Keyv({ 
-  store: new KeyvPostgres('postgresql://user:pass@localhost:5432/dbname', {
+  store: new KeyvPostgres({
+    uri: 'postgresql://user:pass@localhost:5432/dbname',
     table: 'cache'
   })
 })

--- a/packages/sqlite/README.md
+++ b/packages/sqlite/README.md
@@ -15,7 +15,7 @@ const KeyvSqlite = require('@keyvhq/sqlite')
 const Keyv = require('@keyvhq/core')
 
 const keyv = new Keyv({ 
-  store: new KeyvSqlite('sqlite://path/to/database.sqlite')
+  store: new KeyvSqlite({uri: 'sqlite://path/to/database.sqlite'})
 })
 ```
 
@@ -26,7 +26,8 @@ const KeyvSqlite = require('@keyvhq/sqlite')
 const Keyv = require('@keyvhq/core')
 
 const keyv = new Keyv({ 
-  store: new KeyvSqlite('sqlite://path/to/database.sqlite', {
+  store: new KeyvSqlite({
+    uri: 'sqlite://path/to/database.sqlite',
     table: 'cache',
     busyTimeout: 10000
   })


### PR DESCRIPTION
Updated the documentation to match what the constructors actually accept. Postgres and Sqlite do not accept strings directly as URIs.

In the MySQL index.js, the constructor accepts either a string or an options object. That would be another possible approach if we need consistency

Related #91