### PR TITLE
Options constructor

### DIFF
--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -8,9 +8,6 @@
 import { EventEmitter } from 'events'
 
 declare class Keyv<TValue = any> extends EventEmitter {
-  /**
-     * @param opts The options object is also passed through to the storage adapter. Check your storage adapter docs for any extra options.
-     */
   constructor (opts?: Keyv.Options<TValue>);
 
   /** Returns the value. */
@@ -48,7 +45,7 @@ declare namespace Keyv {
     serialize?: ((data: DeserializedData<TValue>) => string) | undefined
     /** A custom deserialization function. */
     deserialize?: ((data: string) => DeserializedData<TValue> | undefined) | undefined
-    /** The storage adapter instance to be used by Keyv. */
+    /** The storage adapter instance to be used by Keyv. Defaults to in-memory map */
     store?: Store<TValue> | Map<string, string>
     /** Default TTL. Can be overridden by specififying a TTL on `.set()`. */
     ttl?: number | undefined

--- a/packages/mongo/README.md
+++ b/packages/mongo/README.md
@@ -36,6 +36,11 @@ const keyv = new Keyv({
 })
 ```
 
+```
+NOTE:
+The mongo adapter deviates from the adapter in terms of uri options, you need to specify url instead of uri when passing the DB URL in the options 
+```
+
 ## License
 
 **@keyvhq/mongo** © [Luke Childs](https://lukechilds.co), Released under the [MIT](https://github.com/microlinkhq/keyv/blob/master/LICENSE.md) License.<br/>

--- a/packages/mongo/README.md
+++ b/packages/mongo/README.md
@@ -12,6 +12,8 @@ npm install --save @keyvhq/core @keyvhq/mongo
 
 ## Usage
 
+> **NOTE**: The mongo uses `url` instead of `uri` to provide the connection string details.
+
 ```js
 const KeyvMongo = require('@keyvhq/mongo')
 const Keyv = require('@keyvhq/core')
@@ -34,11 +36,6 @@ const keyv = new Keyv({
     collection: 'cache'
   })
 })
-```
-
-```
-NOTE:
-The mongo adapter deviates from the adapter in terms of uri options, you need to specify url instead of uri when passing the DB URL in the options 
 ```
 
 ## License

--- a/packages/mongo/src/index.d.ts
+++ b/packages/mongo/src/index.d.ts
@@ -14,7 +14,7 @@ declare class KeyvMongo<TValue> extends EventEmitter implements Store<TValue> {
 
   constructor (uri?: string);
   constructor (options?: KeyvMongo.Options);
-  constructor (uri?: string, options?: KeyvMongo.Options);
+  constructor (uri: string, options?: KeyvMongo.Options);
 
   get (key: string): Promise<TValue | undefined>;
   has (key: string): Promise<boolean>;

--- a/packages/mysql/src/index.d.ts
+++ b/packages/mysql/src/index.d.ts
@@ -12,7 +12,8 @@ declare class KeyvMysql extends EventEmitter implements Store<string | undefined
   namespace?: string | undefined
 
   constructor (uri?: string);
-  constructor (options?: KeyvMysql.Options); // tslint:disable-line:unified-signatures
+  constructor (options?: KeyvMysql.Options);
+  constructor (uri: string, options?: KeyvMysql.Options);
 
   get (key: string): Promise<string | undefined>;
   has (key: string): Promise<boolean>;

--- a/packages/mysql/src/index.js
+++ b/packages/mysql/src/index.js
@@ -19,6 +19,7 @@ class KeyvMysql extends KeyvSql {
         dialect: 'mysql',
         uri: 'mysql://localhost'
       },
+      uri,
       options
     )
 

--- a/packages/mysql/src/index.js
+++ b/packages/mysql/src/index.js
@@ -4,9 +4,14 @@ const KeyvSql = require('@keyvhq/sql')
 const mysql = require('mysql2/promise')
 
 class KeyvMysql extends KeyvSql {
-  constructor (options) {
-    if (typeof options === 'string') {
-      options = { uri: options }
+  constructor (uri, options) {
+    uri = uri || {}
+    if (typeof uri === 'string') {
+      uri = { uri }
+    }
+
+    if (uri.uri) {
+      uri = Object.assign({ uri: uri.uri }, uri)
     }
 
     options = Object.assign(

--- a/packages/postgres/src/index.d.ts
+++ b/packages/postgres/src/index.d.ts
@@ -11,7 +11,9 @@ declare class KeyvPostgres extends EventEmitter implements Store<string | undefi
   readonly ttlSupport: false
   namespace?: string | undefined
 
+  constructor (uri?: string);
   constructor (options?: KeyvPostgres.Options);
+  constructor (uri: string, options?: KeyvPostgres.Options);
 
   get (key: string): Promise<string | undefined>;
   has (key: string): Promise<boolean>;

--- a/packages/postgres/src/index.js
+++ b/packages/postgres/src/index.js
@@ -4,12 +4,21 @@ const KeyvSql = require('@keyvhq/sql')
 const Pool = require('pg').Pool
 
 class KeyvPostgres extends KeyvSql {
-  constructor (options) {
+  constructor (uri, options) {
+    uri = uri || {}
+    if (typeof uri === 'string') {
+      uri = { uri }
+    }
+
+    if (uri.uri) {
+      uri = Object.assign({ uri: uri.uri }, uri)
+    }
     options = Object.assign(
       {
         dialect: 'postgres',
         uri: 'postgresql://localhost:5432'
       },
+      uri,
       options
     )
 

--- a/packages/redis/src/index.d.ts
+++ b/packages/redis/src/index.d.ts
@@ -13,6 +13,7 @@ declare class KeyvRedis extends EventEmitter implements Store<string | undefined
   namespace?: string | undefined
 
   constructor (options?: KeyvRedis.Options);
+  constructor (options?: KeyvRedis.Options);
   constructor (uri: string, options?: KeyvRedis.Options);
 
   get (key: string): Promise<string | undefined>;

--- a/packages/sqlite/src/index.d.ts
+++ b/packages/sqlite/src/index.d.ts
@@ -11,7 +11,9 @@ declare class KeyvSqlite extends EventEmitter implements Store<string | undefine
   readonly ttlSupport: false
   namespace?: string | undefined
 
+  constructor (uri?: string);
   constructor (options?: KeyvSqlite.Options);
+  constructor (uri: string, options?: KeyvSqlite.Options);
 
   get (key: string): Promise<string | undefined>;
   has (key: string): Promise<boolean>;

--- a/packages/sqlite/src/index.js
+++ b/packages/sqlite/src/index.js
@@ -5,12 +5,21 @@ const sqlite3 = require('sqlite3')
 const pify = require('pify')
 
 class KeyvSqlite extends KeyvSql {
-  constructor (options) {
+  constructor (uri, options) {
+    uri = uri || {}
+    if (typeof uri === 'string') {
+      uri = { uri }
+    }
+
+    if (uri.uri) {
+      uri = Object.assign({ uri: uri.uri }, uri)
+    }
     options = Object.assign(
       {
         dialect: 'sqlite',
         uri: 'sqlite://:memory:'
       },
+      uri,
       options
     )
     options.db = options.uri.replace(/^sqlite:\/\//, '')


### PR DESCRIPTION
Major Changes for mysql, sqlite and postgres ( Changes constructor api ), is not breaking change old API will work along with the standard api used by mongo and redis

Fixes #91 