### PR TITLE
fix: associate `emitErrors` with keyv instance

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,20 +4,19 @@ const EventEmitter = require('events')
 const JSONB = require('json-buffer')
 
 class Keyv extends EventEmitter {
-  constructor ({ emitErrors = true, ...options } = {}) {
+  constructor (options = {}) {
     super()
 
     Object.entries(Object.assign(
       {
         serialize: JSONB.stringify,
         deserialize: JSONB.parse,
-        emitErrors: true,
         store: new Map()
       },
       options
     )).forEach(([key, value]) => (this[key] = value))
 
-    if (typeof this.store.on === 'function' && this.emitErrors) {
+    if (typeof this.store.on === 'function') {
       this.store.on('error', error => this.emit('error', error))
     }
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -7,7 +7,7 @@ class Keyv extends EventEmitter {
   constructor ({ emitErrors = true, ...options } = {}) {
     super()
 
-    const normalizedOptions = Object.assign(
+    Object.entries(Object.assign(
       {
         serialize: JSONB.stringify,
         deserialize: JSONB.parse,
@@ -15,16 +15,10 @@ class Keyv extends EventEmitter {
         store: new Map()
       },
       options
-    )
+    )).forEach(([key, value]) => (this[key] = value))
 
-    Object.keys(normalizedOptions).forEach(
-      key => (this[key] = normalizedOptions[key])
-    )
-
-    if (typeof this.store.on === 'function' && emitErrors) {
-      this.store.on('error', error => {
-        this.emit('error', error)
-      })
+    if (typeof this.store.on === 'function' && this.emitErrors) {
+      this.store.on('error', error => this.emit('error', error))
     }
 
     const generateIterator = iterator =>

--- a/packages/offline/test/keyv-redis.js
+++ b/packages/offline/test/keyv-redis.js
@@ -1,14 +1,17 @@
 'use strict'
 
 const KeyvRedis = require('@keyvhq/redis')
+const Keyv = require('@keyvhq/core')
 const test = require('ava')
 
 const keyvOffline = require('../src')
 
-const keyvRedis = new KeyvRedis({
-  uri: 'redis://user:pass@localhost:1337',
-  maxRetriesPerRequest: 0,
-  emitErrors: false
+const keyvRedis = new Keyv({
+  store: new KeyvRedis({
+    uri: 'redis://user:pass@localhost:1337',
+    maxRetriesPerRequest: 0,
+    emitErrors: false
+  })
 })
 
 test('.set return false if store is unreachable', async t => {

--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -8,21 +8,23 @@ const normalizeOptions = (...args) => Object.assign({ emitErrors: true }, ...arg
 
 const normalizeArguments = (input, options) => {
   if (input instanceof Redis) return [input, normalizeOptions(options)]
-  const { uri, ...normalizedOptions } = normalizeOptions(typeof input === 'string' ? { uri: input } : input, options)
-  return [new Redis(uri, normalizedOptions), normalizedOptions]
+  const { uri, ...opts } = Object.assign(typeof input === 'string' ? { uri: input } : input, options)
+  const normalizedOpts = normalizeOptions(opts)
+  return [new Redis(uri, normalizedOpts), normalizedOpts]
 }
 
 class KeyvRedis extends EventEmitter {
   constructor (uri, options) {
     super()
 
-    const [redis, normalizedOptions] = normalizeArguments(uri, options)
+    const [redis, { emitErrors }] = normalizeArguments(uri, options)
 
     this.redis = redis
-    Object.entries(normalizedOptions).forEach(([key, value]) => (this[key] = value))
 
-    if (this.emitErrors) {
-      this.redis.on('error', error => this.emit('error', error))
+    if (emitErrors) {
+      this.redis.on('error', error => {
+        this.emit('error', error)
+      })
     }
   }
 


### PR DESCRIPTION
This PR ensures:

- normalize values is being first.
- values normalized are associated with the keyv instance.

**TODO**

- [x] core
- [x] redis
- [ ] mongo
- [ ] sql