### PR TITLE
build: drop support for node v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     env:
       MYSQL_DB_DATABASE: keyv_test
@@ -45,7 +45,7 @@ jobs:
           mongodb-version: 4.4
       - name: Start MySQL
         run: |
-          sudo /etc/init.d/mysql start
+          sudo systemctl start mysql.service
           mysql -e 'CREATE DATABASE ${{ env.MYSQL_DB_DATABASE }}' -u${{ env.MYSQL_DB_USER }} -p${{ env.MYSQL_DB_PASSWORD }}
           mysql -e 'SET GLOBAL max_connections = 300;' -u${{ env.MYSQL_DB_USER }} -p${{ env.MYSQL_DB_PASSWORD }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     env:
       MYSQL_DB_DATABASE: keyv_test

--- a/packages/mysql/src/index.js
+++ b/packages/mysql/src/index.js
@@ -22,12 +22,11 @@ class KeyvMysql extends KeyvSql {
       uri,
       options
     )
-
+    const pool = mysql.createPool(options.uri)
     options.connect = () =>
       Promise.resolve()
-        .then(() => mysql.createConnection(options.uri))
-        .then(connection => {
-          return sql => connection.execute(sql).then(data => data[0])
+        .then(() => {
+          return sql => pool.execute(sql).then(data => data[0])
         })
 
     super(options)


### PR DESCRIPTION
Node v12 is no longer an active LTS version and support is no longer guaranteed.

Signed-off-by: Jytesh <44925963+Jytesh@users.noreply.github.com>