### PR TITLE
add type definitions to 'memoize' package

### DIFF
--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -41,6 +41,7 @@
     "src"
   ],
   "scripts": {
+    "generate-types": "npx -p typescript tsc ./src/*.js --declaration --allowJs --emitDeclarationOnly",
     "test": "ava"
   },
   "license": "MIT",

--- a/packages/memoize/src/index.d.ts
+++ b/packages/memoize/src/index.d.ts
@@ -1,0 +1,8 @@
+export = memoize;
+declare function memoize(fn: any, keyvOptions: any, { key: getKey, objectMode, staleTtl: rawStaleTtl, ttl: rawTtl, value: getValue }?: {
+    key?: (value: any) => any;
+    objectMode?: boolean;
+    staleTtl: any;
+    ttl: any;
+    value?: (value: any) => any;
+}): any;


### PR DESCRIPTION
this is just the result of running that new script in package.json

I didn't know if you wanted me to also add something so that whenever
this package is published, it regenerates the type definitions, but
if you want that, you could add this to your "scripts" in package.json
`"prepublishOnly": "npm run generate-types",`
